### PR TITLE
Use correct settings and pull in upstream conanfile.py changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,57 +1,46 @@
-# Byte-compiled / optimized / DLL files
-__pycache__/
-*.py[cod]
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
 
-# C extensions
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
 *.so
+*.dylib
+*.dll
 
-# Distribution / packaging
-.Python
-env/
-build/
-develop-eggs/
-dist/
-downloads/
-eggs/
-.eggs/
-lib/
-lib64/
-parts/
-sdist/
-var/
-*.egg-info/
-.installed.cfg
-*.egg
+# Fortran module files
+*.mod
+*.smod
 
-# PyInstaller
-#  Usually these files are written by a python script from a template
-#  before PyInstaller builds the exe, so as to inject date/other infos into it.
-*.manifest
-*.spec
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
 
-# Installer logs
-pip-log.txt
-pip-delete-this-directory.txt
+# Executables
+*.exe
+*.out
+*.app
 
-# Unit test / coverage reports
-htmlcov/
-.tox/
-.coverage
-.coverage.*
-.cache
-nosetests.xml
-coverage.xml
-*,cover
+# Cache
+__pycache__/*
+test_package/__pycache__/*
+test_package/build/*
+build/*
+*.pyc
+tmp/
 
-# Translations
-*.mo
-*.pot
-
-# Django stuff:
-*.log
-
-# Sphinx documentation
-docs/_build/
-
-# PyBuilder
-target/
+# IDE
+.idea/*
+.project
+.pydevproject
+.settings/*
+.ropeproject/*
+## emacs
+*~

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,4 +1,5 @@
 from conans import ConanFile, tools
+from conans.errors import ConanInvalidConfiguration
 import os
 import shutil
 
@@ -18,7 +19,7 @@ class DoxygenConan(ConanFile):
     def config(self):
         if self.settings.os in ["Linux", "Macos"] and self.settings.arch == "x86":
             # self.options.build_from_source = True
-            raise Exception("Not supported x86 for Linux or Macos")
+            raise ConanInvalidConfiguration("Not supported x86 for Linux or Macos")
 
 
     def get_download_filename(self):

--- a/conanfile.py
+++ b/conanfile.py
@@ -92,15 +92,15 @@ class DoxygenConan(ConanFile):
     def package(self):
         if self.settings.os_build == "Linux":
             srcdir = "doxygen-{}/bin".format(self.version)
-            self.copy("*", dst=".", src=srcdir)
+            self.copy("*", dst="bin", src=srcdir)
 
-        self.copy("doxygen", dst=".")
-        self.copy("doxyindexer", dst=".")
-        self.copy("doxysearch.cgi", dst=".")
-        self.copy("*.exe", dst=".")
-        self.copy("*.dylib", dst=".")
-        self.copy("*.dll", dst=".")
-        self.copy("*.cmake", dst=".")
+        self.copy("doxygen", dst="bin")
+        self.copy("doxyindexer", dst="bin")
+        self.copy("doxysearch.cgi", dst="bin")
+        self.copy("*.exe", dst="bin")
+        self.copy("*.dylib", dst="bin")
+        self.copy("*.dll", dst="bin")
+        self.copy("*.cmake", dst="bin")
 
     def package_info(self):
-        self.env_info.path.append(self.package_folder)
+        self.env_info.path.append(os.path.join(self.package_folder, 'bin'))

--- a/conanfile.py
+++ b/conanfile.py
@@ -22,20 +22,19 @@ class DoxygenConan(ConanFile):
 #    default_options = "build_from_source=False"
 
     def config(self):
-        if self.settings.os in ["Linux", "Macos"] and self.settings.arch == "x86":
-            # self.options.build_from_source = True
-            raise ConanInvalidConfiguration("Not supported x86 for Linux or Macos")
+        if self.settings.os_build in ["Linux", "Macos"] and self.settings.arch_build == "x86":
+            raise ConanInvalidConfiguration("x86 is not supported on Linux or Macos")
 
 
     def get_download_filename(self):
         program = "doxygen"
 
-        if self.settings.os == "Windows":
-            if self.settings.arch == "x86":
+        if self.settings.os_build == "Windows":
+            if self.settings.arch_build == "x86":
                 ending = "windows.bin.zip"
             else:
                 ending = "windows.x64.bin.zip"
-        elif self.settings.os == "Macos":
+        elif self.settings.os_build == "Macos":
             program = "Doxygen"
             ending = "dmg"
         else:
@@ -64,16 +63,16 @@ class DoxygenConan(ConanFile):
 
         url = "http://doxygen.nl/files/%s" % self.get_download_filename()
 
-        if self.settings.os == "Linux":
+        if self.settings.os_build == "Linux":
             dest_file = "file.tar.gz"
-        elif self.settings.os == "Macos":
+        elif self.settings.os_build == "Macos":
             dest_file = "file.dmg"
         else:
             dest_file = "file.zip"
 
-        self.output.warn("Downloading: %s" % url)
+        self.output.warn("Downloading: {}".format(url))
         tools.download(url, dest_file, verify=False)
-        if self.settings.os == "Macos":
+        if self.settings.os_build == "Macos":
             self.unpack_dmg(dest_file)
             # Redirect the path of libclang.dylib to be adjacent to the doxygen executable, instead of in Frameworks
             self.run('install_name_tool -change "@executable_path/../Frameworks/libclang.dylib" "@executable_path/libclang.dylib" doxygen')
@@ -83,15 +82,15 @@ class DoxygenConan(ConanFile):
 
         doxyfile = "FindDoxygen.cmake"
         executeable = "doxygen"
-        if self.settings.os == "Windows":
+        if self.settings.os_build == "Windows":
             executeable += ".exe"
 
-        tools.replace_in_file(doxyfile, "## MARKER POINT: DOXYGEN_EXECUTABLE", 'set(DOXYGEN_EXECUTABLE "${CONAN_DOXYGEN_ROOT}/%s" CACHE INTERNAL "")' % executeable)
-        tools.replace_in_file(doxyfile, "## MARKER POINT: DOXYGEN_VERSION", 'set(DOXYGEN_VERSION "%s" CACHE INTERNAL "")' % self.version)
+        tools.replace_in_file(doxyfile, "## MARKER POINT: DOXYGEN_EXECUTABLE", 'set(DOXYGEN_EXECUTABLE "${{CONAN_DOXYGEN_ROOT}}/{0}" CACHE INTERNAL "")'.format(executeable))
+        tools.replace_in_file(doxyfile, "## MARKER POINT: DOXYGEN_VERSION", 'set(DOXYGEN_VERSION "{}" CACHE INTERNAL "")'.format(self.version))
 
     def package(self):
-        if self.settings.os == "Linux":
-            srcdir = "doxygen-%s/bin" % self.version
+        if self.settings.os_build == "Linux":
+            srcdir = "doxygen-{}/bin".format(self.version)
             self.copy("*", dst=".", src=srcdir)
 
         self.copy("doxygen", dst=".")

--- a/conanfile.py
+++ b/conanfile.py
@@ -17,7 +17,7 @@ class DoxygenConan(ConanFile):
     exports = ["LICENSE", "FindDoxygen.cmake"]
     exports_sources = ["FindDoxygen.cmake"]
 
-    settings = {"os": ["Windows", "Linux", "Macos"], "arch": ["x86", "x86_64"]}
+    settings = {"os_build": ["Windows", "Linux", "Macos"], "arch_build": ["x86", "x86_64"]}
 #    options = {"build_from_source": [False, True]} NOT SUPPORTED YET
 #    default_options = "build_from_source=False"
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -59,9 +59,10 @@ class DoxygenConan(ConanFile):
 
     def build(self):
         # source location:
-        # http://doxygen.nl/files/doxygen-1.8.15.src.tar.gz
+        # https://downloads.sourceforge.net/project/doxygen/rel-1.8.14/Doxygen-1.8.14.dmg
 
-        url = "http://doxygen.nl/files/%s" % self.get_download_filename()
+        url = "https://downloads.sourceforge.net/project/doxygen/rel-%s/%s" % (self.version,
+                                                                               self.get_download_filename())
 
         if self.settings.os_build == "Linux":
             dest_file = "file.tar.gz"

--- a/conanfile.py
+++ b/conanfile.py
@@ -8,15 +8,15 @@ class DoxygenConan(ConanFile):
     license = "GNU GPL-2.0"
     description = "A documentation system for C++, C, Java, IDL and PHP --- Note: Dot is disabled in this package"
     url = "http://github.com/inexorgame/conan-doxygen"
-    settings = {"os": ["Windows", "Linux"], "arch": ["x86", "x86_64"]}
+    settings = {"os": ["Windows", "Linux", "Macos"], "arch": ["x86", "x86_64"]}
 #    options = {"build_from_source": [False, True]} NOT SUPPORTED YET
 #    default_options = "build_from_source=False"
     exports = "FindDoxygen.cmake"
 
     def config(self):
-        if self.settings.os == "Linux" and self.settings.arch == "x86":
+        if self.settings.os in ["Linux", "Macos"] and self.settings.arch == "x86":
             # self.options.build_from_source = True
-            raise Exception("Not supported x86 for Linux")
+            raise Exception("Not supported x86 for Linux or Macos")
 
 
     def get_download_filename(self):
@@ -25,12 +25,15 @@ class DoxygenConan(ConanFile):
                 ending = "windows.bin.zip"
             else:
                 ending = "windows.x64.bin.zip"
+        elif self.settings.os == "Macos":
+            program = "Doxygen"
+            ending = "dmg"
         else:
             ending = "linux.bin.tar.gz"
 
-        return "doxygen-%s.%s" % (self.version, ending)
-#       mac would be:
-#       http://ftp.stack.nl/pub/users/dimitri/doxygen-1.8.13.dmg but I dunno how to install dmg files.
+
+        return "%s-%s.%s" % (program, self.version, ending)
+
 
     def build(self):
 
@@ -39,7 +42,12 @@ class DoxygenConan(ConanFile):
 #       source location:
 #       http://ftp.stack.nl/pub/users/dimitri/doxygen-1.8.13.src.tar.gz
 
-        dest_file = "file.tar.gz" if self.settings.os == "Linux" else "file.zip"
+        if self.settings.os == "Linux":
+            dest_file = "file.tar.gz"
+        elif self.settings.os == "Macos":
+            dest_file = "file.dmg"
+        else:
+            dest_file = "file.zip"
         self.output.warn("Downloading: %s" % url)
         tools.download(url, dest_file, verify=False)
         tools.unzip(dest_file)

--- a/conanfile.py
+++ b/conanfile.py
@@ -84,11 +84,16 @@ class DoxygenConan(ConanFile):
         tools.replace_in_file(doxyfile, "## MARKER POINT: DOXYGEN_VERSION", 'set(DOXYGEN_VERSION "%s" CACHE INTERNAL "")' % self.version)
 
     def package(self):
-        if self.settings.os == "Windows":
-            srcdir = ""
-        else:
+        if self.settings.os == "Linux":
             srcdir = "doxygen-%s/bin" % self.version
-        self.copy("*", dst=".", src=srcdir)
+            self.copy("*", dst=".", src=srcdir)
+
+        self.copy("doxygen", dst=".")
+        self.copy("doxyindexer", dst=".")
+        self.copy("doxysearch.cgi", dst=".")
+        self.copy("*.exe", dst=".")
+        self.copy("*.dylib", dst=".")
+        self.copy("*.cmake", dst=".")
 
     def package_info(self):
         self.env_info.path.append(self.package_folder)

--- a/conanfile.py
+++ b/conanfile.py
@@ -93,6 +93,7 @@ class DoxygenConan(ConanFile):
         self.copy("doxysearch.cgi", dst=".")
         self.copy("*.exe", dst=".")
         self.copy("*.dylib", dst=".")
+        self.copy("*.dll", dst=".")
         self.copy("*.cmake", dst=".")
 
     def package_info(self):

--- a/conanfile.py
+++ b/conanfile.py
@@ -9,12 +9,17 @@ class DoxygenConan(ConanFile):
     version = "1.8.13"
     license = "GNU GPL-2.0"
     description = "A documentation system for C++, C, Java, IDL and PHP --- Note: Dot is disabled in this package"
+    topics = ("conan", "doxygen", "installer", "devtool", "documentation")
     url = "https://github.com/inexorgame/conan-doxygen"
+    homepage = "https://github.com/doxygen/doxygen"
+    author = "Inexor <info@inexor.org>"
+    license = "GPL-2.0-only"
+    exports = ["LICENSE", "FindDoxygen.cmake"]
+    exports_sources = ["FindDoxygen.cmake"]
+
     settings = {"os": ["Windows", "Linux", "Macos"], "arch": ["x86", "x86_64"]}
 #    options = {"build_from_source": [False, True]} NOT SUPPORTED YET
 #    default_options = "build_from_source=False"
-    exports = ["LICENSE", "FindDoxygen.cmake"]
-    exports_sources = ["FindDoxygen.cmake"]
 
     def config(self):
         if self.settings.os in ["Linux", "Macos"] and self.settings.arch == "x86":

--- a/conanfile.py
+++ b/conanfile.py
@@ -55,9 +55,9 @@ class DoxygenConan(ConanFile):
 
     def build(self):
         # source location:
-        # http://ftp.stack.nl/pub/users/dimitri/doxygen-1.8.13.src.tar.gz
+        # http://doxygen.nl/files/doxygen-1.8.15.src.tar.gz
 
-        url = "http://ftp.stack.nl/pub/users/dimitri/%s" % self.get_download_filename()
+        url = "http://doxygen.nl/files/%s" % self.get_download_filename()
 
         if self.settings.os == "Linux":
             dest_file = "file.tar.gz"

--- a/conanfile.py
+++ b/conanfile.py
@@ -8,11 +8,12 @@ class DoxygenConan(ConanFile):
     version = "1.8.13"
     license = "GNU GPL-2.0"
     description = "A documentation system for C++, C, Java, IDL and PHP --- Note: Dot is disabled in this package"
-    url = "http://github.com/inexorgame/conan-doxygen"
+    url = "https://github.com/inexorgame/conan-doxygen"
     settings = {"os": ["Windows", "Linux", "Macos"], "arch": ["x86", "x86_64"]}
 #    options = {"build_from_source": [False, True]} NOT SUPPORTED YET
 #    default_options = "build_from_source=False"
-    exports = "FindDoxygen.cmake"
+    exports = ["LICENSE", "FindDoxygen.cmake"]
+    exports_sources = ["FindDoxygen.cmake"]
 
     def config(self):
         if self.settings.os in ["Linux", "Macos"] and self.settings.arch == "x86":
@@ -52,11 +53,10 @@ class DoxygenConan(ConanFile):
             tools.rmdir(mount_point)
 
     def build(self):
+        # source location:
+        # http://ftp.stack.nl/pub/users/dimitri/doxygen-1.8.13.src.tar.gz
 
         url = "http://ftp.stack.nl/pub/users/dimitri/%s" % self.get_download_filename()
-
-#       source location:
-#       http://ftp.stack.nl/pub/users/dimitri/doxygen-1.8.13.src.tar.gz
 
         if self.settings.os == "Linux":
             dest_file = "file.tar.gz"
@@ -74,8 +74,8 @@ class DoxygenConan(ConanFile):
         else:
             tools.unzip(dest_file)
         os.unlink(dest_file)
+
         doxyfile = "FindDoxygen.cmake"
-        shutil.copy(os.path.join(os.path.dirname(__file__), doxyfile), self.build_folder)
         executeable = "doxygen"
         if self.settings.os == "Windows":
             executeable += ".exe"

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from conans import ConanFile
+
+
+class TestPackageConan(ConanFile):
+
+    def test(self):
+        self.output.info("Version:")
+        self.run("doxygen --version")


### PR DESCRIPTION
**Note:** We should be using 1.8.13 for our projects because starting in 1.8.14, the prebuilt Linux version requires `libclang.so.6` to be on the operating system.

- Bring in Mac support previously merged to upstream.
- Bring in upstream fixes to `conanfile.py` that were added to higher version numbers.
- As part of the upstream fix, using `os_build` and `arch_build` for the settings is appropriate for tools. This also fixes the problem where packages randomly "have to" build Doxygen because of compiler settings.
- Get the prebuilt versions from Sourceforge, because the other location doesn't have old versions.
- In the package, store the binaries in the `bin` directory.